### PR TITLE
Fix bad pattern match in isCapSentry.

### DIFF
--- a/src/cheri_cap_common.sail
+++ b/src/cheri_cap_common.sail
@@ -531,9 +531,9 @@ function isCapSealed(cap) = signed(cap.otype) != otype_unsealed
 val isCapSentry : Capability -> bool
 function isCapSentry(cap) =
   match unsigned(cap.otype) {
-    otype_sentry => true,
-    otype_sentry_id => true,
-    otype_sentry_ie => true,
+    otype if otype == otype_sentry    => true,
+    otype if otype == otype_sentry_id => true,
+    otype if otype == otype_sentry_ie => true,
     _  => false
   }
 


### PR DESCRIPTION
Sail does not permit pattern matching on symbols except for constructors: instead it treats them as fresh variables matching a wildcard expression. That means this match was totally broken and always returned true. The only use of this function is in CJALR and the bug meant it was possible to jump to a capability that is not sealed with a sentry type. We fix this by using guards as suggested by @bacam. Fixes #5 .