### PR TITLE
Fix another broken match statement.

### DIFF
--- a/src/cheri_insts.sail
+++ b/src/cheri_insts.sail
@@ -676,9 +676,9 @@ function clause execute (CSeal(cd, cs1, cs2)) = {
     if cs1_val.permit_execute then
       match (cs2_addr) {
         /* 0 is unsealed */
-        otype_sentry => true,
-        otype_sentry_id => true,
-        otype_sentry_ie => true,
+        1 => true, /* otype_sentry */
+        2 => true, /* otype_sentry_id */
+        3 => true, /* otype_sentry_ie */
         /* 4 and 5 are reserved */
         6 => true,
         7 => true,


### PR DESCRIPTION
A quick audit found a similar problem to the one fixed previously (see #5 and #6).  This allowed executable capabilities to be sealed with any otype, not just 1-7. The result would be sealed with the low three bits of the sealing capability's address.  Rather than using pattern guards as for the previous fix I used integer literals as this is easier to read and this code appears in the architecture document.