### PR TITLE
Add stack low water mark.

### DIFF
--- a/src/cheri_addr_checks.sail
+++ b/src/cheri_addr_checks.sail
@@ -205,8 +205,14 @@ function ext_handle_data_check_error(err : ext_data_addr_error) -> unit = {
 function ext_check_phys_mem_read (access_type, paddr, size, aquire, release, reserved, read_meta) =
   Ext_PhysAddr_OK()
 
-function ext_check_phys_mem_write(write_kind, paddr, size, data, metadata) =
+function ext_check_phys_mem_write(write_kind, paddr, size, data, metadata) = {
+  if ((paddr >=_u MSHWMB) & (paddr <_u MSHWM)) then {
+    if get_config_print_reg()
+    then print_reg("MSHWM <- " ^ BitStr(paddr));
+    MSHWM = paddr;
+  };
   Ext_PhysAddr_OK()
+}
 
 /* Is XRET from given mode permitted by extension? */
 function ext_check_xret_priv (p : Privilege) : Privilege -> bool =

--- a/src/cheri_sys_regs.sail
+++ b/src/cheri_sys_regs.sail
@@ -73,6 +73,10 @@ register mccsr : ccsr
 register sccsr : ccsr
 register uccsr : ccsr
 
+/* Stack high water mark registers */
+register MSHWMB    : xlenbits
+register MSHWM     : xlenbits
+
 /* access to CCSRs */
 
 // for now, use a single privilege-independent legalizer
@@ -96,13 +100,22 @@ function clause ext_read_CSR (0x8C0) = Some(uccsr.bits())
 function clause ext_read_CSR (0x9C0) = Some(sccsr.bits())
 function clause ext_read_CSR (0xBC0) = Some(mccsr.bits())
 
+function clause ext_read_CSR (0xBC1) = Some(MSHWM)
+function clause ext_read_CSR (0xBC2) = Some(MSHWMB)
+
 function clause ext_write_CSR (0x8C0, value) = { uccsr = legalize_ccsr(uccsr, value); Some(uccsr.bits()) }
 function clause ext_write_CSR (0x9C0, value) = { sccsr = legalize_ccsr(sccsr, value); Some(sccsr.bits()) }
 function clause ext_write_CSR (0xBC0, value) = { mccsr = legalize_ccsr(mccsr, value); Some(mccsr.bits()) }
 
+function clause ext_write_CSR (0xBC1, value) = { MSHWM  = value; Some(value) }
+function clause ext_write_CSR (0xBC2, value) = { MSHWMB = value; Some(value) }
+
 function clause ext_is_CSR_defined (0x8C0, p) = haveUsrMode()  // uccsr
 function clause ext_is_CSR_defined (0x9C0, p) = haveSupMode() & (p == Machine | p == Supervisor) // sccsr
 function clause ext_is_CSR_defined (0xBC0, p) = p == Machine | p == Supervisor // mccsr
+
+function clause ext_is_CSR_defined (0xBC1, Machine) = true // MSHWM
+function clause ext_is_CSR_defined (0xBC2, Machine) = true // MSHWMB
 
 /* Other architectural registers */
 


### PR DESCRIPTION
This adds a mew CSR, MSLWM.
When written this records the base and top of the written capability as the stack bounds and the address as the current stack low water mark. When read only the integer value of the stack low water mark is returned. Stores update the stack low water mark if the address is between the recorded stack bounds and less than the previous water mark.