### PR TITLE
Fix initialisation of MTCC register.

### DIFF
--- a/src/cheri_regs.sail
+++ b/src/cheri_regs.sail
@@ -128,7 +128,7 @@ function ext_init_regs () = {
   PCC = root_cap_exe;
   nextPCC = root_cap_exe;
 
-  MTCC = root_cap_mem;
+  MTCC = root_cap_exe;
   MTDC = root_cap_mem;
   MScratchC = root_cap_seal;
   MEPCC = root_cap_exe;


### PR DESCRIPTION
The ISA doc says that MTCC should be initialised to the executable root. This makes sense as it needs to be executable to be used as the trap vector. Sail was erroneously setting it to the memory RW root, so fix it here. cheriot-rtos never actually uses this initial value: instead it writes MTCC with a PCC derived capability, hence why this was not noticed before. Spotted by @kliuMsft .