### PR TITLE
Include HINT encodings in build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ SAIL_DEFAULT_INST = $(SAIL_RISCV_MODEL_DIR)/riscv_insts_base.sail \
                     $(SAIL_RISCV_MODEL_DIR)/riscv_insts_cext.sail \
                     $(SAIL_RISCV_MODEL_DIR)/riscv_insts_mext.sail \
                     $(SAIL_RISCV_MODEL_DIR)/riscv_insts_zicsr.sail \
+                    $(SAIL_RISCV_MODEL_DIR)/riscv_insts_hints.sail \
                     $(SAIL_CHERI_MODEL_DIR)/cheri_insts_begin.sail \
                     $(SAIL_CHERI_MODEL_DIR)/cheri_insts.sail \
                     $(SAIL_CHERI_MODEL_DIR)/cheri_insts_cext.sail \


### PR DESCRIPTION
HINT encodings were added to sail-riscv in:
https://github.com/riscv/sail-riscv/commit/c138a086f91552bc158f3bfab9a52221a0819171 It appears the new "riscv_insts_hints.sail" file this commit creates did not get added to the cheriot-sail Makefile.

Add it now to avoid falsely trapping HINT instruction encodings. Encountered when testing with TestRIG, where a valid RVC HINT was being interpreted as `c.illegal' rather than `c.slli.hint.zero.0xc`.